### PR TITLE
Fix checklist item for DevWorkspace/Devfile annotation / runtime class

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ running it with kata (i.e. inside a VM,
 - [x] Remove hard-coded namespace and user
 - [x] Use a minimal set of capabilities to make dnf and podman run work
 - [x] Use a simple DevWorkspace to start a workspace
-- [ ] Avoid adding annotation and runtimeclass in the DevWorkspace/Devfile (issues
+- [x] Avoid adding annotation and runtimeclass in the DevWorkspace/Devfile (issues
 [1](https://issues.redhat.com/browse/CRW-6550) and [2](https://github.com/eclipse-che/che/issues/23032))
 - [ ] Change the sample to use a modified version of UDI that works with root and podman run


### PR DESCRIPTION
I believe the annotation / runtimeclass portion works as expected for the default emptyDir CDE:
<img width="1381" height="863" alt="Screenshot 2025-09-17 at 12 32 46" src="https://github.com/user-attachments/assets/879fb353-0127-4492-a4df-769a77225278" />

podman run does not seem to work though 